### PR TITLE
Add full web and mobile skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.expo/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Project
+# Educational Platform
+
+This repository hosts an educational platform aimed at web, Android, and iOS devices. It uses a React frontend, a mobile React Native app, and a Node.js/Express backend with a SQL database. AI features include personalized recommendations, automatic grading, and a chatbot assistant.
+
+## Project Structure
+
+- **frontend/** – React app for the user interface
+- **backend/** – Node.js/Express.js server and database layer
+- **ai/** – AI models and scripts
+- **docs/** – Documentation and design resources
+- **mobile/** – React Native app for Android and iOS

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,7 @@
+# AI
+
+This folder contains AI models and scripts for features such as personalized recommendations, automatic grading, and the chatbot assistant.
+
+## Example
+
+- `recommendation.py` – Simple placeholder returning mock recommendations.

--- a/ai/recommendation.py
+++ b/ai/recommendation.py
@@ -1,0 +1,20 @@
+"""Simple placeholder for recommendation logic."""
+
+def get_recommendations(user_id):
+    """Return a dummy list of recommendations."""
+    # TODO: Replace with real recommendation model
+    return [
+        {
+            "id": 1,
+            "title": "Introduction to Algebra",
+            "type": "course",
+        },
+        {
+            "id": 2,
+            "title": "Practice Test: Geometry Basics",
+            "type": "quiz",
+        },
+    ]
+
+if __name__ == "__main__":
+    print(get_recommendations("example-user"))

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,10 @@
+# Backend
+
+This directory hosts the Node.js/Express.js server and all backend code. It also includes database access layers for SQL databases such as MySQL or PostgreSQL.
+
+## Running the Server
+
+1. Install dependencies with `npm install`.
+2. Start the server using `npm start`.
+
+The default server listens on port `3001` and exposes a `/api/hello` endpoint returning a simple JSON message.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(cors());
+app.use(express.json());
+
+app.get('/api/hello', (req, res) => {
+  res.json({ message: 'Hello from the backend!' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Backend server running on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "educational-platform-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation
+
+Project documentation including setup guides, design documents, and architecture diagrams will live in this directory.
+
+- `api/` – Backend API details

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,3 @@
+# API Documentation
+
+This directory will contain detailed information about the backend API endpoints.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,14 @@
+# Frontend
+
+This directory contains a simple React application demonstrating the look and feel of the platform.
+
+## Files
+
+- `index.html` – Entry point that loads React and renders the application.
+- `style.css` – Basic black and gold theme used across the pages.
+- `src/app.js` – Main React component.
+
+Clicking the "Say Hello" button makes a request to the backend's `/api/hello`
+endpoint and displays the returned message.
+
+The design uses a black background with gold accents to provide a modern, elegant appearance.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Educational Platform</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- React from CDN -->
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+    <script src="src/app.js"></script>
+</body>
+</html>

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,0 +1,31 @@
+function App() {
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement('header', null, 'Educational Platform'),
+    React.createElement(
+      'main',
+      null,
+      React.createElement('h1', null, 'Welcome!'),
+      React.createElement(
+        'p',
+        null,
+        'This platform helps you learn with personalized recommendations, automatic grading, and a chatbot assistant.'
+      ),
+      React.createElement(
+        'button',
+        {
+          onClick: function () {
+            fetch('http://localhost:3001/api/hello')
+              .then(function (res) { return res.json(); })
+              .then(function (data) { alert(data.message); })
+              .catch(function () { alert('Backend unavailable'); });
+          },
+        },
+        'Say Hello'
+      )
+    )
+  );
+}
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,33 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background-color: #000;
+    color: #FFD700;
+}
+
+header {
+    background-color: #111;
+    padding: 20px;
+    text-align: center;
+    font-size: 1.5em;
+    letter-spacing: 2px;
+}
+
+main {
+    padding: 40px;
+    text-align: center;
+}
+
+button {
+    background-color: #FFD700;
+    border: none;
+    padding: 10px 20px;
+    color: #000;
+    cursor: pointer;
+    font-size: 1em;
+    border-radius: 4px;
+}
+
+button:hover {
+    background-color: #e5c200;
+}

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { StyleSheet, Text, View, StatusBar } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <Text style={styles.title}>Educational Platform</Text>
+      <Text style={styles.subtitle}>Welcome to the mobile app!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    color: '#FFD700',
+    marginBottom: 10,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#FFD700',
+  },
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,9 @@
+# Mobile App
+
+The mobile application is built with React Native using Expo. It supports Android and iOS.
+
+## Files
+- `App.js` – Main entry point for the React Native app.
+- `package.json` – Dependencies and scripts for running the mobile app.
+
+Use `npm start` inside this directory to launch the Expo development server.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "educational-platform-mobile",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.x",
+    "react-native": "0.73.x"
+  }
+}


### PR DESCRIPTION
## Summary
- note project now uses a React Native mobile app
- add backend Express server and API endpoint
- implement a button that fetches from the backend
- create skeleton AI recommendation script
- document project structure including new directories

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_68545b9f57b083259bc43c78c2db8f45